### PR TITLE
[Docs] 디자인 컨벤션 문서 대폭 업데이트

### DIFF
--- a/docs/conventions/17-DESIGN-CONVENTIONS.md
+++ b/docs/conventions/17-DESIGN-CONVENTIONS.md
@@ -163,7 +163,13 @@ export default {
 
         // Status
         'status-success': 'var(--color-status-success)',
+        'status-success-bg': 'var(--color-status-success-bg)',
+        'status-warning': 'var(--color-status-warning)',
+        'status-warning-bg': 'var(--color-status-warning-bg)',
         'status-error': 'var(--color-status-error)',
+        'status-error-bg': 'var(--color-status-error-bg)',
+        'status-disabled': 'var(--color-status-disabled)',
+        'status-disabled-bg': 'var(--color-status-disabled-bg)',
 
         // Sidebar (Nested)
         'sidebar-dark': {
@@ -218,6 +224,11 @@ export default {
 // src/components/common/Button/Button.tsx
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/utils/cn';
+import { type ButtonHTMLAttributes, type ReactNode } from 'react';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode;
+}
 
 const buttonVariants = cva(
   'inline-flex items-center justify-center font-medium transition-colors rounded-md cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed',
@@ -315,7 +326,23 @@ export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
 ```typescript
 // 공통 레이아웃 패턴
-function Layout({ children }: { children: ReactNode }) {
+import { useState, type ReactNode } from 'react';
+import { Sidebar } from '@/components/layout/Sidebar';
+import { designTokens } from '@/styles/design-tokens';
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+function Layout({ children }: LayoutProps) {
+  const [isSidebarExpanded, setIsSidebarExpanded] = useState(true);
+  const [isDarkMode, setIsDarkMode] = useState(true);
+
+  const handleMenuItemClick = (menuId: string) => {
+    // 메뉴 클릭 핸들러
+    console.log('Menu clicked:', menuId);
+  };
+
   return (
     <div className="flex h-screen" style={{ backgroundColor: designTokens.bg.app_default }}>
       <Sidebar


### PR DESCRIPTION
## Summary
- 디자인 토큰 시스템 정의 (CSS 변수 + TypeScript + Tailwind)
- 컬러 팔레트 문서화 (브랜드, 시맨틱, 사이드바 테마)
- CVA 기반 컴포넌트 패턴 및 예제 코드 추가
- Radix UI 컴포넌트 라이브러리 목록화
- 역할별 레이아웃 시스템 문서화
- 반응형 디자인 가이드라인 추가 (모바일 우선)
- WCAG AA 접근성 기준 및 대비율 검증

## Changes
- `docs/conventions/17-DESIGN-CONVENTIONS.md`: +453줄, -67줄

## Related Issue
Closes #3

## Test plan
- [x] 문서 내용 검토
- [x] 코드 예제 정확성 확인
- [x] 마크다운 렌더링 확인